### PR TITLE
Don't force users to publish config file

### DIFF
--- a/src/WebfactionServiceProvider.php
+++ b/src/WebfactionServiceProvider.php
@@ -25,6 +25,8 @@ class WebfactionServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__.'/../config/webfaction.php', 'webfaction');
+
         $this->app->singleton('webfaction', function ($app) {            
             return new Webfaction($app->config->get('webfaction', []));
         });


### PR DESCRIPTION
Since there are only 3 config options, and they aren't really ever going to change, we don't want to force users to publish the config file.

This change is compatible all the way back to Laravel 5.0.

Documentation for reference: https://laravel.com/docs/5.6/packages#configuration